### PR TITLE
fix/build-errors

### DIFF
--- a/src/pages/application.tsx
+++ b/src/pages/application.tsx
@@ -1,5 +1,5 @@
-import { NavbarWrapped } from "@/components/layout/NavbarWrapped";
+import Layout from "@/components/layout";
 
 export default function ApplicationPage() {
-  return <NavbarWrapped>APPLICATION</NavbarWrapped>;
+  return <Layout>APPLICATION</Layout>;
 }

--- a/src/pages/coc.tsx
+++ b/src/pages/coc.tsx
@@ -1,5 +1,5 @@
-import { NavbarWrapped } from "@/components/layout/NavbarWrapped";
+import Layout from "@/components/layout";
 
 export default function COCPage() {
-  return <NavbarWrapped>COC</NavbarWrapped>;
+  return <Layout>COC</Layout>;
 }

--- a/src/pages/inquiries.tsx
+++ b/src/pages/inquiries.tsx
@@ -1,5 +1,5 @@
-import { NavbarWrapped } from "@/components/layout/NavbarWrapped";
+import Layout from "@/components/layout";
 
 export default function InquiriesPage() {
-  return <NavbarWrapped>INQUIRIES</NavbarWrapped>;
+  return <Layout>INQUIRIES</Layout>;
 }

--- a/src/pages/program.tsx
+++ b/src/pages/program.tsx
@@ -1,5 +1,5 @@
-import { NavbarWrapped } from "@/components/layout/NavbarWrapped";
+import Layout from "@/components/layout";
 
 export default function Program() {
-  return <NavbarWrapped>PROGRAM</NavbarWrapped>;
+  return <Layout>PROGRAM</Layout>;
 }

--- a/src/pages/scolarship-support.tsx
+++ b/src/pages/scolarship-support.tsx
@@ -1,5 +1,5 @@
-import { NavbarWrapped } from "@/components/layout/NavbarWrapped";
+import Layout from "@/components/layout";
 
 export default function ScolarshipSupportPage() {
-  return <NavbarWrapped>SCOLARSHIP SUPPORT</NavbarWrapped>;
+  return <Layout>SCOLARSHIP SUPPORT</Layout>;
 }

--- a/src/pages/sponsors.tsx
+++ b/src/pages/sponsors.tsx
@@ -1,5 +1,5 @@
-import { NavbarWrapped } from "@/components/layout/NavbarWrapped";
+import Layout from "@/components/layout";
 
 export default function SponsorsPage() {
-  return <NavbarWrapped>SPONSORS</NavbarWrapped>;
+  return <Layout>SPONSORS</Layout>;
 }


### PR DESCRIPTION
## 🛠️ Fixes

- Vercel에 에러가 나는 `yarn build` 과정에서의 `NavbarWrapped`를 못찾는 이슈를 고쳤습니다.
  - 단순히 `NavbarWrapped`를 `Layout` 컴포넌트로 교체한 건입니다.